### PR TITLE
chore: narrow benchmark source scope

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,10 +37,10 @@ repos:
       - id: benchmark-source-manifest-refresh
         name: benchmark source manifest refresh
         entry: python
-        args: [scripts/build_benchmark_artifacts.py, --write-source-manifest]
+        args: [scripts/refresh_benchmark_source_manifest.py]
         language: system
-        pass_filenames: false
-        files: ^(benchmarks/(conftest\.py|test_bench_(iv|localvol|macro|pde|tree)\.py)|scripts/build_benchmark_artifacts\.py|src/option_pricing/(models/.*\.py|numerics/.*\.py|pricers/.*\.py|types\.py|vol/.*\.py))$
+        pass_filenames: true
+        files: ^(benchmarks/|scripts/|src/option_pricing/)
         stages: [pre-commit]
 
       - id: docs-source-link-guard

--- a/benchmarks/artifacts/benchmark_source_manifest.json
+++ b/benchmarks/artifacts/benchmark_source_manifest.json
@@ -6,6 +6,18 @@
     "benchmarks/test_bench_macro.py": "6c2f7e38efd2f28a6af677b6b8c3d1cf489a5f5382ceed28a6a75f3437902d82",
     "benchmarks/test_bench_pde.py": "3d2718571612b53b00c5f4d8bb172cb8e9d522e2243bb403ad60d94ce14e8f5b",
     "benchmarks/test_bench_tree.py": "310b298ae86bbb7face452b244eff9999a68c1ae75a9318649c01e3f515e1844",
+    "scripts/build_benchmark_artifacts.py": "eef50a9a7137920c0a65a04f6d0e0b6f980b50361b3759977b159ca640ebbc85",
+    "src/option_pricing/__init__.py": "c470a03e6f5bf6f0089b219228f556f2f8b691ed9072665fd6dd71a6ca04dd53",
+    "src/option_pricing/config.py": "6893a0d59c7eee2dceba3496b21ec7a36f6b3d2fae005573512bcbe4205e6517",
+    "src/option_pricing/exceptions.py": "d5de380e6ba0e4dcfca4705b21e69cd0c7955e8b19243f256c5238771ddc93a9",
+    "src/option_pricing/instruments/__init__.py": "f7a634198bede51aed17c0ba3ed812f82a732c47eec0419a334da4ff59e3cd6f",
+    "src/option_pricing/instruments/base.py": "06fd52b1520487dbb66ee61b2f2f3c7fd8dc9b7cb8906ba8d8c683b432b78009",
+    "src/option_pricing/instruments/digital.py": "5b95a372d5c1cd33ed1c644fed9c757e1e5d62e04253c24eddf1005def6af309",
+    "src/option_pricing/instruments/factory.py": "0c0d1bc2aa96e8f93b708a71fd50bd0e584a2d3c393c266b023f0f8b59f6b081",
+    "src/option_pricing/instruments/payoffs.py": "b4509d34523f08b85e5b73d8926902902199dc9c4f9e58c5638282b252e068c8",
+    "src/option_pricing/instruments/vanilla.py": "d634728a5e2a6f57121a964f06454df9dbc35dbbb426c468b02d67452ffa5c13",
+    "src/option_pricing/market/__init__.py": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "src/option_pricing/market/curves.py": "5426b5b2a9f91a336a1d11f158f2ebe1b09e3af5fcba356b3bf43a26f12a9ce7",
     "src/option_pricing/models/__init__.py": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
     "src/option_pricing/models/binomial_crr.py": "bb0c7595b4a07fb8dcc76c72629dcfb518a59c04f9c48899e42810e9d04a0ca0",
     "src/option_pricing/models/black_scholes/__init__.py": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -35,7 +47,6 @@
     "src/option_pricing/numerics/tridiag.py": "e9edf1df0dca1625384f903b00e5a2871a5ecca4767641e6577fa6ec29b4dd21",
     "src/option_pricing/pricers/__init__.py": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
     "src/option_pricing/pricers/black_scholes.py": "fcbe43fc449b920b0ac13ef202755f7d4c7315d94e7c829ce52692795a05c342",
-    "src/option_pricing/pricers/finite_diff.py": "fa5a7374115d17e87452a0cda665bc5feb7079105fe4207c04de2c91fad8a77b",
     "src/option_pricing/pricers/mc.py": "0048f6fe691afeb941d3417d625cb4402bd2b805c4db244c87bb93c73b21da26",
     "src/option_pricing/pricers/pde/__init__.py": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
     "src/option_pricing/pricers/pde/digital_black_scholes.py": "bf0bf1d8f201b5f70019acbc76f2fab9f2eb8b648f54df9f69a4158a9da72fae",
@@ -48,6 +59,9 @@
     "src/option_pricing/pricers/pde_pricer.py": "627a309fc7e0082f19fced4813061a065d18616ba70c0f21c7dd16c28745ed7c",
     "src/option_pricing/pricers/tree.py": "d6528bfa9f6c110c8ea535ab1c03b53b24ebba5967c32d2f468daf770b4db432",
     "src/option_pricing/types.py": "a2683659a6a7d6438d4603a8f388274744355ace8abac229b642c277ac3a8dca",
+    "src/option_pricing/typing.py": "1ffd067f3b8a7b3d98298dab7921fee2307acb52dd3dd9ea6ae341a725226a7d",
+    "src/option_pricing/viz/__init__.py": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "src/option_pricing/viz/publishing.py": "a4b5148b4a06641362c89f21520df9483ba43d38897b5792faa53f402e742cf2",
     "src/option_pricing/vol/__init__.py": "5285f5e0650af980dd8d9714d19e0f486f913f1098859dd2ffaa733edf716cc3",
     "src/option_pricing/vol/arbitrage.py": "124e10de0d42674292a802cc3b9cc2c213fd5ccd4b645c78a5852810a8092d8c",
     "src/option_pricing/vol/implied_vol_common.py": "17dffcf091c0c08deb2e952eac41d3987e732caf2e431cfd2b4294ea71a1ba61",
@@ -86,5 +100,5 @@
     "src/option_pricing/vol/svi/wings.py": "50a26e52bcffd1acc3a178b015480c4977ab24135a69f332def2181c76c965f7",
     "src/option_pricing/vol/vol_types.py": "57f348370ef9e8d6a1acc7efc827fa49cd54f2e7b9131d9ae5bbac19cbea900e"
   },
-  "version": 2
+  "version": 3
 }

--- a/scripts/benchmark_source_scope.py
+++ b/scripts/benchmark_source_scope.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import ast
+import subprocess
+from collections import deque
+from functools import cache
+from importlib.util import resolve_name
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_NAME = "option_pricing"
+BENCHMARK_CONFTEST_PATH = "benchmarks/conftest.py"
+BENCHMARK_BUILDER_PATH = "scripts/build_benchmark_artifacts.py"
+BENCHMARK_SCOPE_DEFINITION_PATHS = ("scripts/benchmark_source_scope.py",)
+
+
+def normalize_repo_path(path: str | Path) -> str:
+    return Path(path).as_posix().lstrip("./")
+
+
+def _path_parts(module_name: str) -> tuple[str, ...]:
+    return tuple(module_name.split("."))
+
+
+def _module_name_from_repo_path(repo_path: str) -> str | None:
+    parts = Path(repo_path).parts
+    if len(parts) < 3 or parts[0] != "src" or parts[1] != PACKAGE_NAME:
+        return None
+    if parts[-1] == "__init__.py":
+        return ".".join(parts[1:-1])
+    if not parts[-1].endswith(".py"):
+        return None
+    return ".".join((*parts[1:-1], Path(parts[-1]).stem))
+
+
+def _package_context_for_repo_path(repo_path: str) -> str | None:
+    module_name = _module_name_from_repo_path(repo_path)
+    if module_name is None:
+        return None
+    if Path(repo_path).name == "__init__.py":
+        return module_name
+    package_name, _, _ = module_name.rpartition(".")
+    return package_name or module_name
+
+
+def _path_for_module_file(root: Path, module_name: str) -> str:
+    path = root.joinpath("src", *_path_parts(module_name)).with_suffix(".py")
+    return normalize_repo_path(path.relative_to(root))
+
+
+def _path_for_package_init(root: Path, module_name: str) -> str:
+    path = root.joinpath("src", *_path_parts(module_name), "__init__.py")
+    return normalize_repo_path(path.relative_to(root))
+
+
+def _iter_parent_package_init_paths(
+    *,
+    root: Path,
+    module_name: str,
+    tracked_paths: frozenset[str],
+) -> set[str]:
+    paths: set[str] = set()
+    parts = _path_parts(module_name)
+    for end in range(1, len(parts) + 1):
+        init_path = _path_for_package_init(root, ".".join(parts[:end]))
+        if init_path in tracked_paths and (root / init_path).is_file():
+            paths.add(init_path)
+    return paths
+
+
+def _resolve_module_reference(
+    *,
+    root: Path,
+    module_name: str,
+    tracked_paths: frozenset[str],
+) -> set[str]:
+    if not module_name.startswith(PACKAGE_NAME):
+        return set()
+
+    paths = _iter_parent_package_init_paths(
+        root=root,
+        module_name=module_name,
+        tracked_paths=tracked_paths,
+    )
+
+    module_file = _path_for_module_file(root, module_name)
+    if module_file in tracked_paths and (root / module_file).is_file():
+        paths.add(module_file)
+    return paths
+
+
+def _resolve_import_from_module(
+    *,
+    importer_path: str,
+    module: str | None,
+    level: int,
+) -> str | None:
+    if level == 0:
+        return module
+
+    package_context = _package_context_for_repo_path(importer_path)
+    if package_context is None:
+        return None
+
+    relative_name = "." * level + (module or "")
+    try:
+        return resolve_name(relative_name, package_context)
+    except ImportError:
+        return None
+
+
+def _iter_repo_local_import_targets(
+    *,
+    root: Path,
+    repo_path: str,
+    tracked_paths: frozenset[str],
+) -> set[str]:
+    tree = ast.parse((root / repo_path).read_text(encoding="utf-8-sig"))
+    discovered: set[str] = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                discovered.update(
+                    _resolve_module_reference(
+                        root=root,
+                        module_name=alias.name,
+                        tracked_paths=tracked_paths,
+                    )
+                )
+            continue
+
+        if not isinstance(node, ast.ImportFrom):
+            continue
+
+        base_module = _resolve_import_from_module(
+            importer_path=repo_path,
+            module=node.module,
+            level=node.level,
+        )
+        if base_module is None:
+            continue
+
+        discovered.update(
+            _resolve_module_reference(
+                root=root,
+                module_name=base_module,
+                tracked_paths=tracked_paths,
+            )
+        )
+
+        package_init = _path_for_package_init(root, base_module)
+        if package_init not in tracked_paths or not (root / package_init).is_file():
+            continue
+
+        for alias in node.names:
+            if alias.name == "*":
+                continue
+            discovered.update(
+                _resolve_module_reference(
+                    root=root,
+                    module_name=f"{base_module}.{alias.name}",
+                    tracked_paths=tracked_paths,
+                )
+            )
+
+    return discovered
+
+
+@cache
+def _git_tracked_paths(root_str: str) -> frozenset[str]:
+    root = Path(root_str)
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=root,
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).decode("utf-8", errors="replace")
+        raise RuntimeError(
+            "Failed to list git-tracked files for benchmark source scope: "
+            f"{detail.strip() or 'unknown git error'}"
+        )
+    return frozenset(
+        normalize_repo_path(path)
+        for path in result.stdout.decode("utf-8", errors="replace").split("\0")
+        if path
+    )
+
+
+def _benchmark_test_seed_paths(root: Path) -> tuple[str, ...]:
+    benchmark_dir = root / "benchmarks"
+    return tuple(
+        sorted(
+            normalize_repo_path(path.relative_to(root))
+            for path in benchmark_dir.glob("test_bench_*.py")
+            if path.is_file()
+        )
+    )
+
+
+def benchmark_source_seed_paths(root: Path = ROOT) -> tuple[str, ...]:
+    return (
+        BENCHMARK_CONFTEST_PATH,
+        *_benchmark_test_seed_paths(root),
+        BENCHMARK_BUILDER_PATH,
+    )
+
+
+def benchmark_scope_definition_paths(root: Path = ROOT) -> tuple[str, ...]:
+    del root
+    return BENCHMARK_SCOPE_DEFINITION_PATHS
+
+
+def is_benchmark_seed_path(path: str | Path) -> bool:
+    normalized = normalize_repo_path(path)
+    if normalized in {BENCHMARK_CONFTEST_PATH, BENCHMARK_BUILDER_PATH}:
+        return True
+    return normalized.startswith("benchmarks/test_bench_") and normalized.endswith(
+        ".py"
+    )
+
+
+@cache
+def _benchmark_source_paths(root_str: str) -> tuple[str, ...]:
+    root = Path(root_str)
+    tracked_paths = _git_tracked_paths(root_str)
+    queue = deque(
+        path for path in benchmark_source_seed_paths(root) if path in tracked_paths
+    )
+    resolved: set[str] = set()
+
+    while queue:
+        repo_path = queue.popleft()
+        if repo_path in resolved or repo_path not in tracked_paths:
+            continue
+        if not (root / repo_path).is_file():
+            continue
+
+        resolved.add(repo_path)
+        for discovered in sorted(
+            _iter_repo_local_import_targets(
+                root=root,
+                repo_path=repo_path,
+                tracked_paths=tracked_paths,
+            )
+        ):
+            if discovered not in resolved:
+                queue.append(discovered)
+
+    return tuple(sorted(resolved))
+
+
+def benchmark_source_paths(root: Path = ROOT) -> tuple[str, ...]:
+    return _benchmark_source_paths(str(root))
+
+
+def iter_benchmark_source_files(root: Path = ROOT) -> tuple[Path, ...]:
+    return tuple(root / repo_path for repo_path in benchmark_source_paths(root))
+
+
+def is_benchmark_freshness_input(path: str | Path, root: Path = ROOT) -> bool:
+    normalized = normalize_repo_path(path)
+    return (
+        normalized in benchmark_source_paths(root)
+        or is_benchmark_seed_path(normalized)
+        or normalized in benchmark_scope_definition_paths(root)
+    )

--- a/scripts/build_benchmark_artifacts.py
+++ b/scripts/build_benchmark_artifacts.py
@@ -18,6 +18,11 @@ SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
+try:
+    from .benchmark_source_scope import iter_benchmark_source_files
+except ImportError:
+    from benchmark_source_scope import iter_benchmark_source_files
+
 import numpy as np
 import pandas as pd
 
@@ -57,20 +62,7 @@ from option_pricing.vol.surface_core import VolSurface
 from option_pricing.vol.svi import SVIParams, svi_total_variance
 
 BENCHMARK_SOURCE_MANIFEST = "benchmark_source_manifest.json"
-BENCHMARK_SOURCE_INPUTS = (
-    "benchmarks/conftest.py",
-    "benchmarks/test_bench_iv.py",
-    "benchmarks/test_bench_localvol.py",
-    "benchmarks/test_bench_macro.py",
-    "benchmarks/test_bench_pde.py",
-    "benchmarks/test_bench_tree.py",
-    "src/option_pricing/models/",
-    "src/option_pricing/numerics/",
-    "src/option_pricing/pricers/",
-    "src/option_pricing/types.py",
-    "src/option_pricing/vol/",
-)
-BENCHMARK_SOURCE_MANIFEST_VERSION = 2
+BENCHMARK_SOURCE_MANIFEST_VERSION = 3
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -139,17 +131,7 @@ def _source_sha256(path: Path) -> str:
 
 
 def _iter_benchmark_source_files() -> list[Path]:
-    files: list[Path] = []
-    for entry in BENCHMARK_SOURCE_INPUTS:
-        path = ROOT / entry
-        if path.is_file():
-            files.append(path)
-            continue
-        if path.is_dir():
-            files.extend(
-                candidate for candidate in path.rglob("*.py") if candidate.is_file()
-            )
-    return sorted(set(files))
+    return list(iter_benchmark_source_files(ROOT))
 
 
 def _benchmark_source_manifest_payload() -> dict[str, Any]:

--- a/scripts/docs_impact.py
+++ b/scripts/docs_impact.py
@@ -7,6 +7,11 @@ import subprocess
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
+try:
+    from .benchmark_source_scope import is_benchmark_freshness_input
+except ImportError:
+    from benchmark_source_scope import is_benchmark_freshness_input
+
 ROOT = Path(__file__).resolve().parents[1]
 EMPTY_TREE_HASH = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
@@ -29,22 +34,6 @@ BENCHMARK_SNAPSHOT_INPUTS = (
     "scripts/render_performance_page.py",
     "scripts/templates/performance.md.template",
 )
-
-BENCHMARK_INPUTS = (
-    "benchmarks/conftest.py",
-    "benchmarks/test_bench_iv.py",
-    "benchmarks/test_bench_localvol.py",
-    "benchmarks/test_bench_macro.py",
-    "benchmarks/test_bench_pde.py",
-    "benchmarks/test_bench_tree.py",
-    "src/option_pricing/models/",
-    "src/option_pricing/numerics/",
-    "src/option_pricing/pricers/",
-    "src/option_pricing/types.py",
-    "src/option_pricing/vol/",
-)
-
-BENCHMARK_FRESHNESS_INPUTS = (*BENCHMARK_SNAPSHOT_INPUTS, *BENCHMARK_INPUTS)
 
 D2_INPUTS = (
     "docs/assets/diagrams/src/",
@@ -169,7 +158,7 @@ def is_docs_sensitive(path: str) -> bool:
     return (
         _matches(path, README_INPUTS)
         or _matches(path, PERFORMANCE_PAGE_INPUTS)
-        or _matches(path, BENCHMARK_INPUTS)
+        or is_benchmark_freshness_input(path, ROOT)
         or _matches(path, D2_INPUTS)
         or _matches(path, VISUAL_ASSET_INPUTS)
         or _matches(path, DOCS_SITE_INPUTS)
@@ -262,7 +251,9 @@ def classify_docs_impact(changed_files: list[str]) -> DocsImpact:
         _matches(path, PERFORMANCE_PAGE_INPUTS) for path in docs_sensitive_files
     )
     benchmark_artifacts_required = any(
-        _matches(path, BENCHMARK_FRESHNESS_INPUTS) for path in docs_sensitive_files
+        _matches(path, BENCHMARK_SNAPSHOT_INPUTS)
+        or is_benchmark_freshness_input(path, ROOT)
+        for path in docs_sensitive_files
     )
     d2_required = any(_matches(path, D2_INPUTS) for path in docs_sensitive_files)
     visual_assets_required = any(

--- a/scripts/refresh_benchmark_source_manifest.py
+++ b/scripts/refresh_benchmark_source_manifest.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+try:
+    from . import build_benchmark_artifacts as benchmark_artifacts
+    from .benchmark_source_scope import is_benchmark_freshness_input
+except ImportError:
+    import build_benchmark_artifacts as benchmark_artifacts
+    from benchmark_source_scope import is_benchmark_freshness_input
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Refresh the benchmark source manifest when pre-commit reports a "
+            "benchmark-sensitive change."
+        )
+    )
+    parser.add_argument("files", nargs="*")
+    return parser.parse_args(argv)
+
+
+def _should_refresh(files: list[str]) -> bool:
+    if not files:
+        return True
+    return any(is_benchmark_freshness_input(path, ROOT) for path in files)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if not _should_refresh(args.files):
+        return 0
+    return benchmark_artifacts.main(["--write-source-manifest"])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_benchmark_artifacts.py
+++ b/tests/test_build_benchmark_artifacts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import scripts.benchmark_source_scope as benchmark_scope
 import scripts.build_benchmark_artifacts as benchmark_artifacts
 
 
@@ -19,8 +20,8 @@ def test_benchmark_source_manifest_payload_normalizes_checkout_newlines(
     monkeypatch.setattr(benchmark_artifacts, "ROOT", tmp_path)
     monkeypatch.setattr(
         benchmark_artifacts,
-        "BENCHMARK_SOURCE_INPUTS",
-        ("benchmarks/sample.py",),
+        "_iter_benchmark_source_files",
+        lambda: [source_path],
     )
 
     _write_sample_source(source_path, newline=b"\n")
@@ -42,8 +43,8 @@ def test_check_benchmark_source_manifest_ignores_checkout_newlines(
     monkeypatch.setattr(benchmark_artifacts, "ROOT", tmp_path)
     monkeypatch.setattr(
         benchmark_artifacts,
-        "BENCHMARK_SOURCE_INPUTS",
-        ("benchmarks/sample.py",),
+        "_iter_benchmark_source_files",
+        lambda: [source_path],
     )
 
     _write_sample_source(source_path, newline=b"\n")
@@ -68,8 +69,8 @@ def test_check_benchmark_source_manifest_requires_current_version(
     monkeypatch.setattr(benchmark_artifacts, "ROOT", tmp_path)
     monkeypatch.setattr(
         benchmark_artifacts,
-        "BENCHMARK_SOURCE_INPUTS",
-        ("benchmarks/sample.py",),
+        "_iter_benchmark_source_files",
+        lambda: [source_path],
     )
 
     _write_sample_source(source_path, newline=b"\n")
@@ -85,3 +86,65 @@ def test_check_benchmark_source_manifest_requires_current_version(
     assert benchmark_artifacts._check_benchmark_source_manifest(artifacts_dir) == 1
     output = capsys.readouterr().out
     assert "Benchmark source manifest format is out of date." in output
+
+
+def test_benchmark_source_scope_tracks_expected_repo_files() -> None:
+    paths = set(benchmark_scope.benchmark_source_paths())
+
+    assert "src/option_pricing/instruments/digital.py" in paths
+    assert "src/option_pricing/viz/publishing.py" in paths
+    assert "src/option_pricing/vol/svi/__init__.py" in paths
+    assert "src/option_pricing/pricers/heston.py" not in paths
+    assert "src/option_pricing/models/heston/__init__.py" not in paths
+
+
+def test_benchmark_source_scope_ignores_untracked_files(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    builder_path = tmp_path / "scripts" / "build_benchmark_artifacts.py"
+    benchmark_path = tmp_path / "benchmarks" / "test_bench_tmp.py"
+    package_root = tmp_path / "src" / "option_pricing"
+    tracked_paths = frozenset(
+        {
+            "benchmarks/test_bench_tmp.py",
+            "scripts/build_benchmark_artifacts.py",
+            "src/option_pricing/__init__.py",
+            "src/option_pricing/pricers/__init__.py",
+            "src/option_pricing/pricers/core.py",
+        }
+    )
+
+    (package_root / "pricers").mkdir(parents=True, exist_ok=True)
+    builder_path.parent.mkdir(parents=True, exist_ok=True)
+    benchmark_path.parent.mkdir(parents=True, exist_ok=True)
+
+    builder_path.write_text(
+        "from option_pricing.pricers.core import price\n",
+        encoding="utf-8",
+    )
+    benchmark_path.write_text(
+        "from option_pricing.pricers.core import price\n",
+        encoding="utf-8",
+    )
+    (package_root / "__init__.py").write_text("", encoding="utf-8")
+    (package_root / "pricers" / "__init__.py").write_text("", encoding="utf-8")
+    (package_root / "pricers" / "core.py").write_text(
+        "def price() -> float:\n    return 1.0\n",
+        encoding="utf-8",
+    )
+    (package_root / "pricers" / "heston.py").write_text(
+        "def unused() -> float:\n    return 0.0\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        benchmark_scope,
+        "_git_tracked_paths",
+        lambda root_str: tracked_paths,
+    )
+
+    paths = set(benchmark_scope.benchmark_source_paths(tmp_path))
+
+    assert "src/option_pricing/pricers/core.py" in paths
+    assert "src/option_pricing/pricers/heston.py" not in paths

--- a/tests/test_docs_impact.py
+++ b/tests/test_docs_impact.py
@@ -74,6 +74,31 @@ def test_benchmark_source_change_targets_performance_page() -> None:
     assert impact.review_paths == []
 
 
+def test_non_benchmark_src_change_no_longer_requires_benchmark_refresh() -> None:
+    impact = classify_docs_impact(["src/option_pricing/pricers/heston.py"])
+
+    assert impact.docs_sensitive is True
+    assert impact.docs_site_required is True
+    assert impact.benchmark_artifacts_required is False
+    assert impact.visual_assets_required is True
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "src/option_pricing/pricers/pde_pricer.py",
+        "src/option_pricing/instruments/digital.py",
+        "src/option_pricing/viz/publishing.py",
+    ],
+)
+def test_benchmark_relevant_src_change_requires_benchmark_refresh(path: str) -> None:
+    impact = classify_docs_impact([path])
+
+    assert impact.docs_sensitive is True
+    assert impact.docs_site_required is True
+    assert impact.benchmark_artifacts_required is True
+
+
 def test_git_changed_files_reports_missing_refs_actionably() -> None:
     with pytest.raises(RuntimeError, match="checkout is shallow|base/head commits"):
         git_changed_files("refs/heads/definitely-missing-docs-impact-ref", "HEAD")

--- a/tests/test_docs_workflows.py
+++ b/tests/test_docs_workflows.py
@@ -107,15 +107,12 @@ def test_pre_commit_refreshes_benchmark_source_manifest_for_benchmark_inputs() -
     )
 
     assert hook["entry"] == "python"
-    assert hook["args"] == [
-        "scripts/build_benchmark_artifacts.py",
-        "--write-source-manifest",
-    ]
-    assert hook["pass_filenames"] is False
+    assert hook["args"] == ["scripts/refresh_benchmark_source_manifest.py"]
+    assert hook["pass_filenames"] is True
     assert hook["stages"] == ["pre-commit"]
-    assert "test_bench_" in str(hook["files"])
+    assert "benchmarks/" in str(hook["files"])
+    assert "scripts/" in str(hook["files"])
     assert "src/option_pricing/" in str(hook["files"])
-    assert "scripts/build_benchmark_artifacts\\.py" in str(hook["files"])
 
 
 def test_dev_extras_include_pre_commit_for_local_docs_guards() -> None:

--- a/tests/test_refresh_benchmark_source_manifest.py
+++ b/tests/test_refresh_benchmark_source_manifest.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import argparse
+
+import scripts.refresh_benchmark_source_manifest as refresh_manifest
+
+
+def test_main_refreshes_manifest_for_benchmark_sensitive_files(
+    monkeypatch,
+) -> None:
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr(
+        refresh_manifest,
+        "_parse_args",
+        lambda argv=None: argparse.Namespace(
+            files=["src/option_pricing/pricers/pde_pricer.py"]
+        ),
+    )
+    monkeypatch.setattr(
+        refresh_manifest,
+        "is_benchmark_freshness_input",
+        lambda path, root: path.endswith("pde_pricer.py"),
+    )
+    monkeypatch.setattr(
+        refresh_manifest.benchmark_artifacts,
+        "main",
+        lambda argv=None: calls.append(list(argv or [])) or 0,
+    )
+
+    assert refresh_manifest.main() == 0
+    assert calls == [["--write-source-manifest"]]
+
+
+def test_main_skips_manifest_refresh_for_out_of_scope_files(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr(
+        refresh_manifest,
+        "_parse_args",
+        lambda argv=None: argparse.Namespace(
+            files=["src/option_pricing/pricers/heston.py"]
+        ),
+    )
+    monkeypatch.setattr(
+        refresh_manifest,
+        "is_benchmark_freshness_input",
+        lambda path, root: False,
+    )
+    monkeypatch.setattr(
+        refresh_manifest.benchmark_artifacts,
+        "main",
+        lambda argv=None: calls.append(list(argv or [])) or 0,
+    )
+
+    assert refresh_manifest.main() == 0
+    assert calls == []


### PR DESCRIPTION
## Summary
Narrow the benchmark source scope so benchmark artifact refreshes only trigger for files that actually feed the benchmark suite.

## Why
The previous benchmark manifest logic used broad directory-level inputs, which caused unrelated source changes to invalidate benchmark freshness and force unnecessary manifest/artifact refreshes. This makes pre-commit and docs-impact checks noisier than they need to be.

## Changes
- Added `scripts/benchmark_source_scope.py` to compute benchmark-relevant source files from benchmark entrypoints by following repo-local imports across tracked Python files.
- Updated `scripts/build_benchmark_artifacts.py` to use the computed source set instead of hard-coded broad directories, and bumped the benchmark source manifest format/version.
- Added `scripts/refresh_benchmark_source_manifest.py` so pre-commit can refresh the manifest only when changed filenames are actually benchmark-sensitive.
- Updated `.pre-commit-config.yaml` to pass changed filenames into the benchmark-manifest hook and widened the hook file matcher so the script can decide scope itself.
- Updated `scripts/docs_impact.py` so benchmark artifact refreshes are required only for benchmark-relevant source changes, not every change under broad pricing/model/vol directories.
- Refreshed `benchmarks/artifacts/benchmark_source_manifest.json` to reflect the narrower tracked source set.
- Added/expanded tests covering the new scope resolver, docs-impact behavior, pre-commit hook wiring, and conditional manifest refresh behavior.

## Test plan
- [ ] `ruff check .`
- [ ] `black --check .`
- [ ] `mypy`
- [ ] `pytest -q tests`
- [ ] notebooks: `pytest -q demos --nbmake` (if applicable)

## Docs
- [ ] README / docs updated (if needed)

## Notes / risks
Reviewers should pay attention to the benchmark source discovery logic:
- it intentionally follows tracked repo-local Python imports from benchmark seed files, so dynamic imports or benchmark-relevant code paths that are not imported from those entrypoints may be missed
- the pre-commit hook now runs on a broader file pattern, but should no-op for out-of-scope changes because the new wrapper script filters by benchmark freshness inputs
- the manifest format/version changed, so stale checkouts will need the refreshed artifact file committed alongside the code change