### PR TITLE
marketdata: add Phase A contract schemas and storage safeguards

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
     hooks:
       - id: mypy
         stages: [pre-commit, pre-push]
+        entry: python -X utf8 -m mypy
         args: [--config-file=pyproject.toml]
         pass_filenames: false
         # .pre-commit-config.yaml

--- a/src/option_pricing/marketdata/contracts.py
+++ b/src/option_pricing/marketdata/contracts.py
@@ -1,13 +1,19 @@
-from dataclasses import dataclass
-from pathlib import Path
-from typing import TypeVar
+"""Compatibility exports for marketdata contract result objects."""
 
-T = TypeVar("T")
+from .schemas import (
+    BackfillResult,
+    ModelValidationBundleResult,
+    PipelineResult,
+    ResearchBundleResult,
+    ResultStats,
+    SnapshotResult,
+)
 
-
-@dataclass(frozen=True, slots=True)
-class ResultStats:
-    rows_in: int = 0
-    rows_out: int = 0
-    files_written: tuple[Path, ...] = ()
-    warnings: tuple[str, ...] = ()
+__all__ = [
+    "BackfillResult",
+    "ModelValidationBundleResult",
+    "PipelineResult",
+    "ResearchBundleResult",
+    "ResultStats",
+    "SnapshotResult",
+]

--- a/src/option_pricing/marketdata/contracts.py
+++ b/src/option_pricing/marketdata/contracts.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True, slots=True)
+class ResultStats:
+    rows_in: int = 0
+    rows_out: int = 0
+    files_written: tuple[Path, ...] = ()
+    warnings: tuple[str, ...] = ()

--- a/src/option_pricing/marketdata/pipeline.py
+++ b/src/option_pricing/marketdata/pipeline.py
@@ -1,24 +1,5 @@
-"""
-POSSIBLE OUTLINE HERE MAYBE FOR DIFF MODULE
+"""Marketdata pipeline orchestration hooks.
 
-from dataclasses import dataclass, field
-from pathlib import Path
-from typing import Generic, TypeVar
-
-T = TypeVar("T")
-
-
-@dataclass(frozen=True, slots=True)
-class ResultStats:
-    rows_in: int = 0
-    rows_out: int = 0
-    files_written: tuple[Path, ...] = ()
-    warnings: tuple[str, ...] = ()
-
-
-@dataclass(frozen=True, slots=True)
-class PipelineResult(Generic[T]):
-    value: T
-    metadata: RunMetadata
-    stats: ResultStats = field(default_factory=ResultStats)
+Phase A1 defines the contracts and storage safeguards only. Provider loading,
+normalization, and bundle export are intentionally left to later phases.
 """

--- a/src/option_pricing/marketdata/schemas.py
+++ b/src/option_pricing/marketdata/schemas.py
@@ -3,7 +3,7 @@ Implement:
 - config dataclasses
 - run metadata dataclasses
 - typed result objects
-- canonical dataset names
+- canonical dataset_name names
 - optional small enums:
     - Right
     - DatasetLayer
@@ -17,7 +17,19 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from enum import StrEnum
 from pathlib import Path
+from typing import Literal
+
+import pandas as pd
+
+type PandasSchemaDtype = Literal[
+    "datetime64[ns, UTC]",
+    "datetime64[ns]",
+    "Float64",
+    "Int64",
+    "string",
+]
 
 
 def _require_aware_utc(name: str, value: datetime) -> None:
@@ -71,6 +83,10 @@ class RunMetadata:
         _require_aware_utc("started_at", self.started_at)
 
 
+#########
+# Constants
+#########
+
 EQUITY_QUOTES_COLUMNS = (
     "symbol",
     "quote_ts",
@@ -83,7 +99,7 @@ EQUITY_QUOTES_COLUMNS = (
     "asof",
 )
 
-EQUITY_QUOTES_DTYPES = {
+EQUITY_QUOTES_DTYPES: dict[str, PandasSchemaDtype] = {
     "symbol": "string",
     "quote_ts": "datetime64[ns, UTC]",
     "bid": "Float64",
@@ -110,7 +126,7 @@ EQUITY_BARS_COLUMNS = (
     "asof",
 )
 
-EQUITY_BARS_DTYPES = {
+EQUITY_BARS_DTYPES: dict[str, PandasSchemaDtype] = {
     "symbol": "string",
     "bar_ts": "datetime64[ns, UTC]",
     "timeframe": "string",
@@ -147,7 +163,7 @@ OPTION_CHAIN_COLUMNS = (
     "asof",
 )
 
-OPTION_CHAIN_DTYPES = {
+OPTION_CHAIN_DTYPES: dict[str, PandasSchemaDtype] = {
     "underlying": "string",
     "contract_symbol": "string",
     "quote_ts": "datetime64[ns, UTC]",
@@ -179,7 +195,7 @@ FRED_SERIES_COLUMNS = (
     "asof",
 )
 
-FRED_SERIES_DTYPES = {
+FRED_SERIES_DTYPES: dict[str, PandasSchemaDtype] = {
     "series_id": "string",
     "observation_date": "datetime64[ns]",
     "value": "Float64",
@@ -202,7 +218,7 @@ MARKET_SNAPSHOT_COLUMNS = (
     "option_contract_count",
 )
 
-MARKET_SNAPSHOT_DTYPES = {
+MARKET_SNAPSHOT_DTYPES: dict[str, PandasSchemaDtype] = {
     "underlying": "string",
     "asof": "datetime64[ns, UTC]",
     "spot": "Float64",
@@ -215,18 +231,183 @@ MARKET_SNAPSHOT_DTYPES = {
     "option_contract_count": "Int64",
 }
 
-DATASET_COLUMNS = {
-    "equity_quotes": EQUITY_QUOTES_COLUMNS,
-    "equity_bars": EQUITY_BARS_COLUMNS,
-    "option_chain": OPTION_CHAIN_COLUMNS,
-    "fred_series": FRED_SERIES_COLUMNS,
-    "market_snapshot": MARKET_SNAPSHOT_COLUMNS,
+
+class DatasetName(StrEnum):
+    """
+    Enum object for safe internal handling of dataset_name calling
+    """
+
+    EQUITY_QUOTES = "equity_quotes"
+    EQUITY_BARS = "equity_bars"
+    OPTION_CHAIN = "option_chain"
+    FRED_SERIES = "fred_series"
+    MARKET_SNAPSHOT = "market_snapshot"
+
+
+DATASET_COLUMNS: dict[DatasetName, tuple[str, ...]] = {
+    DatasetName.EQUITY_QUOTES: EQUITY_QUOTES_COLUMNS,
+    DatasetName.EQUITY_BARS: EQUITY_BARS_COLUMNS,
+    DatasetName.OPTION_CHAIN: OPTION_CHAIN_COLUMNS,
+    DatasetName.FRED_SERIES: FRED_SERIES_COLUMNS,
+    DatasetName.MARKET_SNAPSHOT: MARKET_SNAPSHOT_COLUMNS,
 }
 
-DATASET_DTYPES = {
-    "equity_quotes": EQUITY_QUOTES_DTYPES,
-    "equity_bars": EQUITY_BARS_DTYPES,
-    "option_chain": OPTION_CHAIN_DTYPES,
-    "fred_series": FRED_SERIES_DTYPES,
-    "market_snapshot": MARKET_SNAPSHOT_DTYPES,
+DATASET_DTYPES: dict[DatasetName, dict[str, PandasSchemaDtype]] = {
+    DatasetName.EQUITY_QUOTES: EQUITY_QUOTES_DTYPES,
+    DatasetName.EQUITY_BARS: EQUITY_BARS_DTYPES,
+    DatasetName.OPTION_CHAIN: OPTION_CHAIN_DTYPES,
+    DatasetName.FRED_SERIES: FRED_SERIES_DTYPES,
+    DatasetName.MARKET_SNAPSHOT: MARKET_SNAPSHOT_DTYPES,
 }
+
+
+###########
+# Validation helpers
+###########
+
+
+def parse_dataset_name(dataset_name: DatasetName | str) -> DatasetName:
+    """Normalize a dataset name into a DatasetName enum."""
+
+    if isinstance(dataset_name, DatasetName):
+        return dataset_name
+
+    if not isinstance(dataset_name, str):
+        raise TypeError(
+            f"dataset_name must be a DatasetName or str, got {type(dataset_name).__name__}"
+        )
+
+    try:
+        return DatasetName(dataset_name.strip().lower())
+    except ValueError as exc:
+        known = ", ".join(item.value for item in DatasetName)
+        raise ValueError(
+            f"Unknown marketdata dataset_name {dataset_name!r}. "
+            f"Expected one of: {known}"
+        ) from exc
+
+
+def dataset_columns(dataset_name: DatasetName | str) -> tuple[str, ...]:
+    """Return required canonical columns for a marketdata dataset."""
+
+    parsed_name = parse_dataset_name(dataset_name)
+    return DATASET_COLUMNS[parsed_name]
+
+
+def dataset_dtypes(dataset_name: DatasetName | str) -> dict[str, PandasSchemaDtype]:
+    """Return expected pandas dtypes for a marketdata dataset."""
+
+    parsed_name = parse_dataset_name(dataset_name)
+    return DATASET_DTYPES[parsed_name]
+
+
+def validate_columns(
+    frame: pd.DataFrame,
+    dataset_name: DatasetName | str,
+    *,
+    allow_extra: bool = True,
+) -> None:
+    """Validate that a DataFrame has the required columns for a dataset."""
+
+    parsed_name = parse_dataset_name(dataset_name)
+    required = dataset_columns(parsed_name)
+    actual = tuple(frame.columns)
+
+    missing = [column for column in required if column not in actual]
+
+    if missing:
+        raise ValueError(f"{parsed_name.value} is missing required columns: {missing}")
+
+    if not allow_extra:
+        extra = [column for column in actual if column not in required]
+
+        if extra:
+            raise ValueError(
+                f"{parsed_name.value} has unexpected extra columns: {extra}"
+            )
+
+
+def validate_dtypes(
+    frame: pd.DataFrame,
+    dataset_name: DatasetName | str,
+    *,
+    allow_extra: bool = True,
+) -> None:
+    """Validate that a DataFrame has the expected pandas dtypes for a dataset."""
+
+    parsed_name = parse_dataset_name(dataset_name)
+
+    # First make sure the required columns are present.
+    validate_columns(frame, parsed_name, allow_extra=allow_extra)
+
+    expected_dtypes = dataset_dtypes(parsed_name)
+
+    mismatches: dict[str, tuple[str, str]] = {}
+
+    for column, expected_dtype in expected_dtypes.items():
+        actual_dtype = str(frame[column].dtype)
+
+        if actual_dtype != expected_dtype:
+            mismatches[column] = (actual_dtype, expected_dtype)
+
+    if mismatches:
+        details = ", ".join(
+            f"{column}: actual={actual!r}, expected={expected!r}"
+            for column, (actual, expected) in mismatches.items()
+        )
+
+        raise TypeError(f"{parsed_name.value} has dtype mismatches: {details}")
+
+
+def order_columns(frame: pd.DataFrame, dataset_name: DatasetName | str) -> pd.DataFrame:
+    """Return frame with canonical columns first and extras after."""
+
+    required = dataset_columns(dataset_name)
+    extra = [column for column in frame.columns if column not in required]
+    return frame.loc[:, [*required, *extra]]
+
+
+def coerce_frame(
+    frame: pd.DataFrame,
+    dataset_name: DatasetName | str,
+    *,
+    allow_extra: bool = True,
+) -> pd.DataFrame:
+    """Return a copy of frame coerced to the expected pandas dtypes."""
+
+    parsed_name = parse_dataset_name(dataset_name)
+    validate_columns(frame, parsed_name, allow_extra=allow_extra)
+
+    out = frame.copy()
+    expected_dtypes = dataset_dtypes(parsed_name)
+
+    for column, dtype in expected_dtypes.items():
+        try:
+            if dtype == "datetime64[ns, UTC]":
+                out[column] = pd.to_datetime(out[column], utc=True)
+
+            elif dtype == "datetime64[ns]":
+                out[column] = pd.to_datetime(out[column]).dt.tz_localize(None)
+
+            elif dtype == "Float64":
+                out[column] = pd.to_numeric(out[column], errors="raise").astype(
+                    pd.Float64Dtype()
+                )
+
+            elif dtype == "Int64":
+                out[column] = pd.to_numeric(out[column], errors="raise").astype(
+                    pd.Int64Dtype()
+                )
+
+            else:
+                out[column] = out[column].astype(dtype)
+
+        except Exception as exc:
+            raise TypeError(
+                f"Could not coerce column {column!r} in dataset "
+                f"{parsed_name.value!r} to dtype {dtype!r}"
+            ) from exc
+
+    validate_dtypes(out, parsed_name, allow_extra=allow_extra)
+
+    return out

--- a/src/option_pricing/marketdata/schemas.py
+++ b/src/option_pricing/marketdata/schemas.py
@@ -1,21 +1,9 @@
-"""
-Implement:
-- config dataclasses
-- run metadata dataclasses
-- typed result objects
-- canonical dataset_name names
-- optional small enums:
-    - Right
-    - DatasetLayer
-    - ProviderName
-
-Definition of done:
-every pipeline function returns a typed result, not loose dicts
-"""
+"""Marketdata schema contracts and validation helpers."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
@@ -83,9 +71,94 @@ class RunMetadata:
         _require_aware_utc("started_at", self.started_at)
 
 
+@dataclass(frozen=True, slots=True)
+class ResultStats:
+    rows_in: int = 0
+    rows_out: int = 0
+    files_written: tuple[Path, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class PipelineResult[T]:
+    value: T
+    metadata: RunMetadata
+    stats: ResultStats = field(default_factory=ResultStats)
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotResult:
+    frame: pd.DataFrame
+    metadata: RunMetadata
+    stats: ResultStats = field(default_factory=ResultStats)
+
+
+@dataclass(frozen=True, slots=True)
+class ModelValidationBundleResult:
+    manifest: Mapping[str, object]
+    manifest_path: Path
+    metadata: RunMetadata
+    artifact_paths: tuple[Path, ...] = ()
+    stats: ResultStats = field(default_factory=ResultStats)
+
+
+@dataclass(frozen=True, slots=True)
+class ResearchBundleResult:
+    root_path: Path
+    metadata: RunMetadata
+    artifact_paths: tuple[Path, ...] = ()
+    stats: ResultStats = field(default_factory=ResultStats)
+
+
+@dataclass(frozen=True, slots=True)
+class BackfillResult:
+    metadata: RunMetadata
+    run_ids: tuple[str, ...] = ()
+    artifact_paths: tuple[Path, ...] = ()
+    stats: ResultStats = field(default_factory=ResultStats)
+
+
 #########
 # Constants
 #########
+
+MARKET_INPUTS_SCHEMA_VERSION = "market_inputs.v1"
+OPTION_CHAIN_SCHEMA_VERSION = "option_chain.v1"
+CLEANED_QUOTES_SCHEMA_VERSION = "cleaned_quotes.v1"
+REJECTED_QUOTES_SCHEMA_VERSION = "rejected_quotes.v1"
+HESTON_QUOTES_SCHEMA_VERSION = "heston_quotes.v1"
+SURFACE_INPUTS_SCHEMA_VERSION = "surface_inputs.v1"
+MODEL_VALIDATION_BUNDLE_VERSION = "model_validation_bundle.v1"
+
+MODEL_VALIDATION_MANIFEST_REQUIRED_FIELDS = (
+    "artifact_schema_version",
+    "run_id",
+    "created_at_utc",
+    "library_commit",
+    "underlying",
+    "valuation_timestamp_utc",
+    "spot_source",
+    "rate_source",
+    "rate_compounding",
+    "dividend_yield_source",
+    "day_count",
+    "quote_cleaning_policy",
+    "rows",
+    "warnings",
+    "artifacts",
+)
+
+_SECRET_MANIFEST_KEY_TERMS = frozenset(
+    {
+        "api_key",
+        "secret_key",
+        "token",
+        "password",
+        "alpaca_api_key",
+        "alpaca_secret_key",
+        "fred_api_key",
+    }
+)
 
 EQUITY_QUOTES_COLUMNS = (
     "symbol",
@@ -185,6 +258,136 @@ OPTION_CHAIN_DTYPES: dict[str, PandasSchemaDtype] = {
     "asof": "datetime64[ns, UTC]",
 }
 
+CLEANED_QUOTES_COLUMNS = (
+    "underlying",
+    "contract_symbol",
+    "quote_id",
+    "quote_ts",
+    "asof",
+    "expiry",
+    "expiry_years",
+    "strike",
+    "right",
+    "bid",
+    "ask",
+    "mid",
+    "iv",
+    "vega",
+    "delta",
+    "gamma",
+    "theta",
+    "rho",
+    "open_interest",
+    "moneyness",
+    "source",
+    "cleaning_policy",
+)
+
+CLEANED_QUOTES_DTYPES: dict[str, PandasSchemaDtype] = {
+    "underlying": "string",
+    "contract_symbol": "string",
+    "quote_id": "string",
+    "quote_ts": "datetime64[ns, UTC]",
+    "asof": "datetime64[ns, UTC]",
+    "expiry": "datetime64[ns]",
+    "expiry_years": "Float64",
+    "strike": "Float64",
+    "right": "string",
+    "bid": "Float64",
+    "ask": "Float64",
+    "mid": "Float64",
+    "iv": "Float64",
+    "vega": "Float64",
+    "delta": "Float64",
+    "gamma": "Float64",
+    "theta": "Float64",
+    "rho": "Float64",
+    "open_interest": "Int64",
+    "moneyness": "Float64",
+    "source": "string",
+    "cleaning_policy": "string",
+}
+
+REJECTED_QUOTES_COLUMNS = (
+    "underlying",
+    "contract_symbol",
+    "quote_id",
+    "quote_ts",
+    "asof",
+    "expiry",
+    "strike",
+    "right",
+    "bid",
+    "ask",
+    "mid",
+    "iv",
+    "vega",
+    "source",
+    "rejection_reason",
+    "rejection_detail",
+    "cleaning_policy",
+)
+
+REJECTED_QUOTES_DTYPES: dict[str, PandasSchemaDtype] = {
+    "underlying": "string",
+    "contract_symbol": "string",
+    "quote_id": "string",
+    "quote_ts": "datetime64[ns, UTC]",
+    "asof": "datetime64[ns, UTC]",
+    "expiry": "datetime64[ns]",
+    "strike": "Float64",
+    "right": "string",
+    "bid": "Float64",
+    "ask": "Float64",
+    "mid": "Float64",
+    "iv": "Float64",
+    "vega": "Float64",
+    "source": "string",
+    "rejection_reason": "string",
+    "rejection_detail": "string",
+    "cleaning_policy": "string",
+}
+
+HESTON_QUOTES_COLUMNS = (
+    "underlying",
+    "contract_symbol",
+    "quote_id",
+    "asof",
+    "expiry",
+    "expiry_years",
+    "strike",
+    "right",
+    "mid",
+    "bid",
+    "ask",
+    "iv",
+    "vega",
+    "option_type",
+    "label",
+    "source",
+    "cleaning_policy",
+)
+
+HESTON_QUOTES_DTYPES: dict[str, PandasSchemaDtype] = {
+    "underlying": "string",
+    "contract_symbol": "string",
+    "quote_id": "string",
+    "asof": "datetime64[ns, UTC]",
+    "expiry": "datetime64[ns]",
+    "expiry_years": "Float64",
+    "strike": "Float64",
+    "right": "string",
+    "mid": "Float64",
+    "bid": "Float64",
+    "ask": "Float64",
+    "iv": "Float64",
+    "vega": "Float64",
+    "option_type": "string",
+    "label": "string",
+    "source": "string",
+    "cleaning_policy": "string",
+}
+
 FRED_SERIES_COLUMNS = (
     "series_id",
     "observation_date",
@@ -231,6 +434,65 @@ MARKET_SNAPSHOT_DTYPES: dict[str, PandasSchemaDtype] = {
     "option_contract_count": "Int64",
 }
 
+MARKET_INPUTS_COLUMNS = (
+    "underlying",
+    "asof",
+    "spot",
+    "spot_source",
+    "rate",
+    "rate_source",
+    "rate_observation_date",
+    "rate_compounding",
+    "dividend_yield",
+    "dividend_yield_source",
+    "day_count",
+)
+
+MARKET_INPUTS_DTYPES: dict[str, PandasSchemaDtype] = {
+    "underlying": "string",
+    "asof": "datetime64[ns, UTC]",
+    "spot": "Float64",
+    "spot_source": "string",
+    "rate": "Float64",
+    "rate_source": "string",
+    "rate_observation_date": "datetime64[ns]",
+    "rate_compounding": "string",
+    "dividend_yield": "Float64",
+    "dividend_yield_source": "string",
+    "day_count": "string",
+}
+
+SURFACE_INPUTS_COLUMNS = (
+    "underlying",
+    "quote_id",
+    "asof",
+    "expiry",
+    "expiry_years",
+    "strike",
+    "right",
+    "mid",
+    "iv",
+    "source",
+    "cleaning_policy",
+)
+
+SURFACE_INPUTS_DTYPES: dict[str, PandasSchemaDtype] = {
+    "underlying": "string",
+    "quote_id": "string",
+    "asof": "datetime64[ns, UTC]",
+    "expiry": "datetime64[ns]",
+    "expiry_years": "Float64",
+    "strike": "Float64",
+    "right": "string",
+    "mid": "Float64",
+    "iv": "Float64",
+    "source": "string",
+    "cleaning_policy": "string",
+}
+
+MODEL_VALIDATION_BUNDLE_COLUMNS: tuple[str, ...] = ()
+MODEL_VALIDATION_BUNDLE_DTYPES: dict[str, PandasSchemaDtype] = {}
+
 
 class DatasetName(StrEnum):
     """
@@ -240,24 +502,42 @@ class DatasetName(StrEnum):
     EQUITY_QUOTES = "equity_quotes"
     EQUITY_BARS = "equity_bars"
     OPTION_CHAIN = "option_chain"
+    CLEANED_QUOTES = "cleaned_quotes"
+    REJECTED_QUOTES = "rejected_quotes"
+    HESTON_QUOTES = "heston_quotes"
     FRED_SERIES = "fred_series"
     MARKET_SNAPSHOT = "market_snapshot"
+    MARKET_INPUTS = "market_inputs"
+    SURFACE_INPUTS = "surface_inputs"
+    MODEL_VALIDATION_BUNDLE = "model_validation_bundle"
 
 
 DATASET_COLUMNS: dict[DatasetName, tuple[str, ...]] = {
     DatasetName.EQUITY_QUOTES: EQUITY_QUOTES_COLUMNS,
     DatasetName.EQUITY_BARS: EQUITY_BARS_COLUMNS,
     DatasetName.OPTION_CHAIN: OPTION_CHAIN_COLUMNS,
+    DatasetName.CLEANED_QUOTES: CLEANED_QUOTES_COLUMNS,
+    DatasetName.REJECTED_QUOTES: REJECTED_QUOTES_COLUMNS,
+    DatasetName.HESTON_QUOTES: HESTON_QUOTES_COLUMNS,
     DatasetName.FRED_SERIES: FRED_SERIES_COLUMNS,
     DatasetName.MARKET_SNAPSHOT: MARKET_SNAPSHOT_COLUMNS,
+    DatasetName.MARKET_INPUTS: MARKET_INPUTS_COLUMNS,
+    DatasetName.SURFACE_INPUTS: SURFACE_INPUTS_COLUMNS,
+    DatasetName.MODEL_VALIDATION_BUNDLE: MODEL_VALIDATION_BUNDLE_COLUMNS,
 }
 
 DATASET_DTYPES: dict[DatasetName, dict[str, PandasSchemaDtype]] = {
     DatasetName.EQUITY_QUOTES: EQUITY_QUOTES_DTYPES,
     DatasetName.EQUITY_BARS: EQUITY_BARS_DTYPES,
     DatasetName.OPTION_CHAIN: OPTION_CHAIN_DTYPES,
+    DatasetName.CLEANED_QUOTES: CLEANED_QUOTES_DTYPES,
+    DatasetName.REJECTED_QUOTES: REJECTED_QUOTES_DTYPES,
+    DatasetName.HESTON_QUOTES: HESTON_QUOTES_DTYPES,
     DatasetName.FRED_SERIES: FRED_SERIES_DTYPES,
     DatasetName.MARKET_SNAPSHOT: MARKET_SNAPSHOT_DTYPES,
+    DatasetName.MARKET_INPUTS: MARKET_INPUTS_DTYPES,
+    DatasetName.SURFACE_INPUTS: SURFACE_INPUTS_DTYPES,
+    DatasetName.MODEL_VALIDATION_BUNDLE: MODEL_VALIDATION_BUNDLE_DTYPES,
 }
 
 
@@ -411,3 +691,81 @@ def coerce_frame(
     validate_dtypes(out, parsed_name, allow_extra=allow_extra)
 
     return out
+
+
+def _is_secret_manifest_key(key: str) -> bool:
+    normalized = key.strip().lower()
+    return (
+        normalized in _SECRET_MANIFEST_KEY_TERMS
+        or "api_key" in normalized
+        or "secret_key" in normalized
+        or normalized.endswith("token")
+        or "password" in normalized
+    )
+
+
+def _find_secret_manifest_keys(value: object, path: str = "") -> list[str]:
+    secret_keys: list[str] = []
+
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            key_text = str(key)
+            key_path = f"{path}.{key_text}" if path else key_text
+
+            if _is_secret_manifest_key(key_text):
+                secret_keys.append(key_path)
+
+            secret_keys.extend(_find_secret_manifest_keys(item, key_path))
+
+    elif isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        for index, item in enumerate(value):
+            item_path = f"{path}[{index}]" if path else f"[{index}]"
+            secret_keys.extend(_find_secret_manifest_keys(item, item_path))
+
+    return secret_keys
+
+
+def validate_model_validation_manifest(manifest: Mapping[str, object]) -> None:
+    """Validate the minimum model-validation bundle manifest contract."""
+
+    if not isinstance(manifest, Mapping):
+        raise TypeError("manifest must be a mapping")
+
+    missing = [
+        field
+        for field in MODEL_VALIDATION_MANIFEST_REQUIRED_FIELDS
+        if field not in manifest
+    ]
+
+    if missing:
+        raise ValueError(
+            "model_validation_bundle manifest is missing required fields: " f"{missing}"
+        )
+
+    artifact_schema_version = manifest["artifact_schema_version"]
+    if artifact_schema_version != MODEL_VALIDATION_BUNDLE_VERSION:
+        raise ValueError(
+            "model_validation_bundle manifest has artifact_schema_version "
+            f"{artifact_schema_version!r}; expected "
+            f"{MODEL_VALIDATION_BUNDLE_VERSION!r}"
+        )
+
+    secret_keys = _find_secret_manifest_keys(manifest)
+    if secret_keys:
+        raise ValueError(
+            "model_validation_bundle manifest contains secret-looking keys: "
+            f"{secret_keys}"
+        )
+
+
+def validate_manifest(
+    manifest: Mapping[str, object],
+    dataset_name: DatasetName | str = DatasetName.MODEL_VALIDATION_BUNDLE,
+) -> None:
+    """Validate a dataset manifest when a manifest-level contract exists."""
+
+    parsed_name = parse_dataset_name(dataset_name)
+    if parsed_name != DatasetName.MODEL_VALIDATION_BUNDLE:
+        raise ValueError(f"No manifest validator is defined for {parsed_name.value!r}")
+
+    validate_model_validation_manifest(manifest)

--- a/src/option_pricing/marketdata/storage.py
+++ b/src/option_pricing/marketdata/storage.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
-from .schemas import RunMetadata, StorageConfig
+from .schemas import RunMetadata, StorageConfig, validate_model_validation_manifest
 
 if TYPE_CHECKING:
     from pandas import DataFrame
@@ -50,9 +50,15 @@ _PARTITION_ORDERS: dict[tuple[str, str], tuple[str, ...]] = {
     ("silver", "equity_bars"): ("symbol", "timeframe", "date"),
     ("silver", "option_chain"): ("underlying", "asof_date"),
     ("silver", "fred_series"): ("series_id", "date"),
+    ("silver", "market_inputs"): ("underlying", "date", "run_id"),
+    ("silver", "cleaned_quotes"): ("underlying", "date", "run_id"),
+    ("silver", "rejected_quotes"): ("underlying", "date", "run_id"),
     ("gold", "market_snapshot"): ("underlying", "date"),
     ("gold", "curves"): ("date",),
     ("gold", "vol_inputs"): ("underlying", "date"),
+    ("gold", "heston_quotes"): ("underlying", "date", "run_id"),
+    ("gold", "surface_inputs"): ("underlying", "date", "run_id"),
+    ("gold", "model_validation_bundle"): ("underlying", "date", "run_id"),
 }
 
 
@@ -173,6 +179,7 @@ class LocalStorage:
         filename: str | None = None,
         compression: str | None = None,
         index: bool = False,
+        overwrite: bool = False,
     ) -> Path:
         """Write a DataFrame to a partitioned Parquet file."""
 
@@ -196,6 +203,10 @@ class LocalStorage:
 
         target_path = target_dir / self._frame_filename(filename)
         parquet_compression = compression or self.config.compression
+        if target_path.exists() and not overwrite:
+            raise FileExistsError(
+                f"{target_path} already exists; pass overwrite=True to replace it"
+            )
 
         try:
             frame.to_parquet(
@@ -286,6 +297,7 @@ class LocalStorage:
         layer: str = "bronze",
         partitions: Mapping[str, PartitionValue] | None = None,
         filename: str = "manifest.json",
+        overwrite: bool = False,
     ) -> Path:
         """Write a JSON manifest next to a dataset partition."""
 
@@ -304,11 +316,19 @@ class LocalStorage:
         target_dir.mkdir(parents=True, exist_ok=True)
 
         manifest_path = target_dir / self._json_filename(filename)
+        if manifest_path.exists() and not overwrite:
+            raise FileExistsError(
+                f"{manifest_path} already exists; pass overwrite=True to replace it"
+            )
+
         payload = _jsonify_object(manifest)
         payload.setdefault("dataset", dataset_name)
         payload.setdefault("layer", layer_name)
         payload.setdefault("partitions", self._serialise_partitions(ordered_partitions))
         payload.setdefault("written_at", _utcnow().isoformat())
+
+        if dataset_name == "model_validation_bundle":
+            validate_model_validation_manifest(payload)
 
         self._write_json_atomic(manifest_path, payload)
         self._append_jsonl(

--- a/tests/marketdata/test_a1_contract_storage_integration.py
+++ b/tests/marketdata/test_a1_contract_storage_integration.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from option_pricing.marketdata.schemas import (
+    MODEL_VALIDATION_BUNDLE_VERSION,
+    StorageConfig,
+    coerce_frame,
+    validate_columns,
+)
+from option_pricing.marketdata.storage import LocalStorage
+
+
+@pytest.fixture
+def fake_parquet(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_to_parquet(
+        self: pd.DataFrame,
+        path: str,
+        compression: str | None = None,
+        index: bool = False,
+    ) -> None:
+        del compression
+        payload = self if index else self.reset_index(drop=True)
+        payload.to_pickle(path)
+
+    monkeypatch.setattr(pd.DataFrame, "to_parquet", _fake_to_parquet)
+
+
+def _cleaned_quotes() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "underlying": "SPY",
+                "contract_symbol": "SPY260619C00400000",
+                "quote_id": "quote-001",
+                "quote_ts": "2026-05-22T14:30:00Z",
+                "asof": "2026-05-22T14:31:00Z",
+                "expiry": "2026-06-19",
+                "expiry_years": "0.0767",
+                "strike": "400",
+                "right": "call",
+                "bid": "12.30",
+                "ask": "12.50",
+                "mid": "12.40",
+                "iv": "0.21",
+                "vega": "0.35",
+                "delta": "0.52",
+                "gamma": "0.03",
+                "theta": "-0.02",
+                "rho": "0.01",
+                "open_interest": "42",
+                "moneyness": "1.01",
+                "source": "fixture",
+                "cleaning_policy": "phase_a_default",
+            }
+        ]
+    )
+
+
+def _rejected_quotes() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "underlying": "SPY",
+                "contract_symbol": "SPY260619P00300000",
+                "quote_id": "quote-002",
+                "quote_ts": "2026-05-22T14:30:00Z",
+                "asof": "2026-05-22T14:31:00Z",
+                "expiry": "2026-06-19",
+                "strike": "300",
+                "right": "put",
+                "bid": "0.00",
+                "ask": "0.01",
+                "mid": "0.005",
+                "iv": "0.95",
+                "vega": "0.01",
+                "source": "fixture",
+                "rejection_reason": "wide_or_stale",
+                "rejection_detail": "synthetic rejection for contract test",
+                "cleaning_policy": "phase_a_default",
+            }
+        ]
+    )
+
+
+def _heston_quotes() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "underlying": "SPY",
+                "contract_symbol": "SPY260619C00400000",
+                "quote_id": "quote-001",
+                "asof": "2026-05-22T14:31:00Z",
+                "expiry": "2026-06-19",
+                "expiry_years": "0.0767",
+                "strike": "400",
+                "right": "call",
+                "mid": "12.40",
+                "bid": "12.30",
+                "ask": "12.50",
+                "iv": "0.21",
+                "vega": "0.35",
+                "option_type": "call",
+                "label": "SPY 2026-06-19 400C",
+                "source": "fixture",
+                "cleaning_policy": "phase_a_default",
+            }
+        ]
+    )
+
+
+def test_a1_contracts_and_storage_support_model_validation_layout(
+    tmp_path,
+    fake_parquet: None,
+) -> None:
+    storage = LocalStorage(StorageConfig(root=tmp_path))
+    partitions = {
+        "underlying": "SPY",
+        "date": "2026-05-22",
+        "run_id": "test-run",
+    }
+
+    cleaned = coerce_frame(_cleaned_quotes(), "cleaned_quotes")
+    rejected = coerce_frame(_rejected_quotes(), "rejected_quotes")
+    heston = coerce_frame(_heston_quotes(), "heston_quotes")
+
+    validate_columns(cleaned, "cleaned_quotes")
+    validate_columns(rejected, "rejected_quotes")
+    validate_columns(heston, "heston_quotes")
+
+    cleaned_path = storage.write_frame(
+        cleaned,
+        dataset="cleaned_quotes",
+        layer="silver",
+        partitions=partitions,
+        filename="cleaned_quotes",
+    )
+    rejected_path = storage.write_frame(
+        rejected,
+        dataset="rejected_quotes",
+        layer="silver",
+        partitions=partitions,
+        filename="rejected_quotes",
+    )
+    heston_path = storage.write_frame(
+        heston,
+        dataset="heston_quotes",
+        layer="gold",
+        partitions=partitions,
+        filename="heston_quotes",
+    )
+
+    manifest_path = storage.write_manifest(
+        {
+            "artifact_schema_version": MODEL_VALIDATION_BUNDLE_VERSION,
+            "run_id": "test-run",
+            "created_at_utc": "2026-05-22T14:35:00Z",
+            "library_commit": "abc123",
+            "underlying": "SPY",
+            "valuation_timestamp_utc": "2026-05-22T14:31:00Z",
+            "spot_source": "fixture",
+            "rate_source": "fixture",
+            "rate_compounding": "continuous",
+            "dividend_yield_source": "fixture",
+            "day_count": "ACT/365",
+            "quote_cleaning_policy": "phase_a_default",
+            "rows": {
+                "cleaned_quotes": int(len(cleaned)),
+                "rejected_quotes": int(len(rejected)),
+                "heston_quotes": int(len(heston)),
+            },
+            "warnings": [],
+            "artifacts": {
+                "cleaned_quotes": cleaned_path.as_posix(),
+                "rejected_quotes": rejected_path.as_posix(),
+                "heston_quotes": heston_path.as_posix(),
+            },
+        },
+        dataset="model_validation_bundle",
+        layer="gold",
+        partitions=partitions,
+    )
+
+    assert cleaned_path.exists()
+    assert rejected_path.exists()
+    assert heston_path.exists()
+    assert manifest_path.exists()
+    assert cleaned_path.parent.parts[-3:] == (
+        "underlying=SPY",
+        "date=2026-05-22",
+        "run_id=test-run",
+    )
+    assert heston_path.parent.parts[-3:] == (
+        "underlying=SPY",
+        "date=2026-05-22",
+        "run_id=test-run",
+    )
+    assert manifest_path.name == "manifest.json"

--- a/tests/marketdata/test_marketdata_schemas.py
+++ b/tests/marketdata/test_marketdata_schemas.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pandas as pd
+import pytest
+
+from option_pricing.marketdata.schemas import (
+    CLEANED_QUOTES_COLUMNS,
+    MODEL_VALIDATION_BUNDLE_VERSION,
+    MODEL_VALIDATION_MANIFEST_REQUIRED_FIELDS,
+    DatasetName,
+    RunMetadata,
+    coerce_frame,
+    dataset_columns,
+    dataset_dtypes,
+    validate_columns,
+    validate_dtypes,
+    validate_model_validation_manifest,
+)
+
+
+def _cleaned_quote_record() -> dict[str, object]:
+    return {
+        "underlying": "SPY",
+        "contract_symbol": "SPY260619C00400000",
+        "quote_id": "quote-001",
+        "quote_ts": "2026-05-22T14:30:00Z",
+        "asof": "2026-05-22T14:31:00Z",
+        "expiry": "2026-06-19",
+        "expiry_years": "0.0767",
+        "strike": "400",
+        "right": "call",
+        "bid": "12.30",
+        "ask": "12.50",
+        "mid": "12.40",
+        "iv": "0.21",
+        "vega": "0.35",
+        "delta": "0.52",
+        "gamma": "0.03",
+        "theta": "-0.02",
+        "rho": "0.01",
+        "open_interest": "42",
+        "moneyness": "1.01",
+        "source": "fixture",
+        "cleaning_policy": "phase_a_default",
+    }
+
+
+def _valid_manifest() -> dict[str, object]:
+    return {
+        "artifact_schema_version": MODEL_VALIDATION_BUNDLE_VERSION,
+        "run_id": "test-run",
+        "created_at_utc": "2026-05-22T14:35:00Z",
+        "library_commit": "abc123",
+        "underlying": "SPY",
+        "valuation_timestamp_utc": "2026-05-22T14:31:00Z",
+        "spot_source": "fixture",
+        "rate_source": "fixture",
+        "rate_compounding": "continuous",
+        "dividend_yield_source": "fixture",
+        "day_count": "ACT/365",
+        "quote_cleaning_policy": "phase_a_default",
+        "rows": {"cleaned_quotes": 1},
+        "warnings": [],
+        "artifacts": {"cleaned_quotes": "silver/cleaned_quotes"},
+    }
+
+
+def test_phase_a_dataset_contracts_are_registered() -> None:
+    expected_names = {
+        "market_inputs",
+        "cleaned_quotes",
+        "rejected_quotes",
+        "heston_quotes",
+        "surface_inputs",
+        "model_validation_bundle",
+    }
+
+    assert expected_names.issubset({dataset.value for dataset in DatasetName})
+    assert dataset_columns("cleaned_quotes") == CLEANED_QUOTES_COLUMNS
+    assert dataset_columns("model_validation_bundle") == ()
+    assert dataset_dtypes("model_validation_bundle") == {}
+    assert dataset_dtypes("market_inputs")["rate_compounding"] == "string"
+
+
+def test_unknown_dataset_name_raises_clear_error() -> None:
+    with pytest.raises(ValueError, match="Unknown marketdata dataset_name"):
+        dataset_columns("made_up_dataset")
+
+
+def test_validate_columns_reports_missing_and_rejects_extra_when_strict() -> None:
+    frame = pd.DataFrame([_cleaned_quote_record()])
+
+    validate_columns(frame, "cleaned_quotes")
+    validate_columns(frame.assign(extra_field="ok"), "cleaned_quotes")
+
+    with pytest.raises(ValueError, match="unexpected extra columns"):
+        validate_columns(
+            frame.assign(extra_field="nope"),
+            "cleaned_quotes",
+            allow_extra=False,
+        )
+
+    with pytest.raises(ValueError, match="missing required columns"):
+        validate_columns(frame.drop(columns=["quote_id"]), "cleaned_quotes")
+
+
+def test_coerce_frame_handles_phase_a_dtypes() -> None:
+    frame = pd.DataFrame([_cleaned_quote_record()])
+
+    coerced = coerce_frame(frame, "cleaned_quotes")
+
+    validate_dtypes(coerced, "cleaned_quotes")
+    assert str(coerced["quote_ts"].dtype) == "datetime64[ns, UTC]"
+    assert str(coerced["expiry"].dtype) == "datetime64[ns]"
+    assert str(coerced["open_interest"].dtype) == "Int64"
+    assert str(coerced["mid"].dtype) == "Float64"
+
+
+def test_run_metadata_requires_aware_datetimes() -> None:
+    with pytest.raises(ValueError, match="asof must be timezone-aware"):
+        RunMetadata(
+            run_id="test-run",
+            asof=datetime(2026, 5, 22, 14, 31),
+            started_at=datetime(2026, 5, 22, 14, 32, tzinfo=UTC),
+        )
+
+
+def test_model_validation_manifest_contract() -> None:
+    validate_model_validation_manifest(_valid_manifest())
+
+    missing = _valid_manifest()
+    missing.pop("artifacts")
+    with pytest.raises(ValueError, match="missing required fields"):
+        validate_model_validation_manifest(missing)
+
+    wrong_version = _valid_manifest()
+    wrong_version["artifact_schema_version"] = "model_validation_bundle.v0"
+    with pytest.raises(ValueError, match="artifact_schema_version"):
+        validate_model_validation_manifest(wrong_version)
+
+    secret = _valid_manifest()
+    secret["ALPACA_API_KEY"] = "not-for-manifests"
+    with pytest.raises(ValueError, match="secret-looking keys"):
+        validate_model_validation_manifest(secret)
+
+    assert "artifacts" in MODEL_VALIDATION_MANIFEST_REQUIRED_FIELDS

--- a/tests/marketdata/test_marketdata_storage.py
+++ b/tests/marketdata/test_marketdata_storage.py
@@ -6,7 +6,11 @@ from datetime import UTC, date, datetime
 import pandas as pd
 import pytest
 
-from option_pricing.marketdata.schemas import RunMetadata, StorageConfig
+from option_pricing.marketdata.schemas import (
+    MODEL_VALIDATION_BUNDLE_VERSION,
+    RunMetadata,
+    StorageConfig,
+)
 from option_pricing.marketdata.storage import LocalStorage
 
 
@@ -33,6 +37,26 @@ def fake_parquet(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(pd.DataFrame, "to_parquet", _fake_to_parquet)
     monkeypatch.setattr(pd, "read_parquet", _fake_read_parquet)
+
+
+def _valid_model_validation_manifest() -> dict[str, object]:
+    return {
+        "artifact_schema_version": MODEL_VALIDATION_BUNDLE_VERSION,
+        "run_id": "test-run",
+        "created_at_utc": "2026-05-22T14:35:00Z",
+        "library_commit": "abc123",
+        "underlying": "SPY",
+        "valuation_timestamp_utc": "2026-05-22T14:31:00Z",
+        "spot_source": "fixture",
+        "rate_source": "fixture",
+        "rate_compounding": "continuous",
+        "dividend_yield_source": "fixture",
+        "day_count": "ACT/365",
+        "quote_cleaning_policy": "phase_a_default",
+        "rows": {"cleaned_quotes": 1},
+        "warnings": [],
+        "artifacts": {"cleaned_quotes": "silver/cleaned_quotes"},
+    }
 
 
 def test_write_and_read_frame_round_trips_partitioned_data(
@@ -178,4 +202,139 @@ def test_write_frame_raises_helpful_error_when_parquet_engine_is_missing(
             frame,
             dataset="equity_quotes",
             partitions={"date": "2026-03-16"},
+        )
+
+
+def test_phase_a_frame_paths_and_overwrite_policy(tmp_path, fake_parquet: None) -> None:
+    storage = LocalStorage(tmp_path)
+    frame = pd.DataFrame({"quote_id": ["quote-001"], "mid": [12.4]})
+
+    path = storage.write_frame(
+        frame,
+        dataset="cleaned_quotes",
+        layer="silver",
+        partitions={
+            "run_id": "test-run",
+            "date": "2026-05-22",
+            "underlying": "SPY",
+        },
+        filename="cleaned_quotes",
+    )
+
+    expected_path = (
+        tmp_path
+        / "silver"
+        / "cleaned_quotes"
+        / "underlying=SPY"
+        / "date=2026-05-22"
+        / "run_id=test-run"
+        / "cleaned_quotes.parquet"
+    )
+    assert path == expected_path
+    assert path.exists()
+
+    with pytest.raises(FileExistsError, match="overwrite=True"):
+        storage.write_frame(
+            frame,
+            dataset="cleaned_quotes",
+            layer="silver",
+            partitions={
+                "underlying": "SPY",
+                "date": "2026-05-22",
+                "run_id": "test-run",
+            },
+            filename="cleaned_quotes",
+        )
+
+    assert (
+        storage.write_frame(
+            frame,
+            dataset="cleaned_quotes",
+            layer="silver",
+            partitions={
+                "underlying": "SPY",
+                "date": "2026-05-22",
+                "run_id": "test-run",
+            },
+            filename="cleaned_quotes",
+            overwrite=True,
+        )
+        == expected_path
+    )
+
+
+def test_model_validation_manifest_path_validation_and_overwrite_policy(
+    tmp_path,
+) -> None:
+    storage = LocalStorage(tmp_path)
+
+    manifest_path = storage.write_manifest(
+        _valid_model_validation_manifest(),
+        dataset="model_validation_bundle",
+        layer="gold",
+        partitions={
+            "date": "2026-05-22",
+            "run_id": "test-run",
+            "underlying": "SPY",
+        },
+    )
+
+    expected_path = (
+        tmp_path
+        / "gold"
+        / "model_validation_bundle"
+        / "underlying=SPY"
+        / "date=2026-05-22"
+        / "run_id=test-run"
+        / "manifest.json"
+    )
+    assert manifest_path == expected_path
+
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert payload["dataset"] == "model_validation_bundle"
+    assert payload["artifact_schema_version"] == MODEL_VALIDATION_BUNDLE_VERSION
+
+    with pytest.raises(FileExistsError, match="overwrite=True"):
+        storage.write_manifest(
+            _valid_model_validation_manifest(),
+            dataset="model_validation_bundle",
+            layer="gold",
+            partitions={
+                "underlying": "SPY",
+                "date": "2026-05-22",
+                "run_id": "test-run",
+            },
+        )
+
+    assert (
+        storage.write_manifest(
+            _valid_model_validation_manifest(),
+            dataset="model_validation_bundle",
+            layer="gold",
+            partitions={
+                "underlying": "SPY",
+                "date": "2026-05-22",
+                "run_id": "test-run",
+            },
+            overwrite=True,
+        )
+        == expected_path
+    )
+
+
+def test_model_validation_manifest_rejects_secret_keys(tmp_path) -> None:
+    storage = LocalStorage(tmp_path)
+    manifest = _valid_model_validation_manifest()
+    manifest["api_key"] = "do-not-write"
+
+    with pytest.raises(ValueError, match="secret-looking keys"):
+        storage.write_manifest(
+            manifest,
+            dataset="model_validation_bundle",
+            layer="gold",
+            partitions={
+                "underlying": "SPY",
+                "date": "2026-05-22",
+                "run_id": "test-run",
+            },
         )


### PR DESCRIPTION
## Summary
What does this PR change?

Adds the Phase A1 marketdata contract layer for the real-data pipeline. This turns `marketdata.schemas` into the central source of truth for dataset contracts, schema versions, validation/coercion helpers, and typed result objects.

This PR also adds the first storage safeguards needed by the Phase A artifact layout, including Phase A partition ordering, deterministic artifact filename support, overwrite protection, and model-validation manifest validation.

## Why
Why is this needed?

Phase A needs stable artifact contracts before local snapshots, normalization, provider adapters, or Heston calibration are implemented. Later sprints should be able to write `market_inputs`, `cleaned_quotes`, `rejected_quotes`, `heston_quotes`, `surface_inputs`, and `model_validation_bundle` outputs without inventing schemas or path rules during normalization.

This keeps the pipeline boundary clear:
- contracts and storage safety in Phase A1
- local fixture/snapshot loading later
- normalization and quote cleaning later
- provider/network work later
- Heston calibration later

## Changes
- Added schema version constants for Phase A marketdata artifacts.
- Added Phase A dataset contracts for:
  - `market_inputs`
  - `cleaned_quotes`
  - `rejected_quotes`
  - `heston_quotes`
  - `surface_inputs`
  - `model_validation_bundle`
- Extended `DatasetName`, `DATASET_COLUMNS`, and `DATASET_DTYPES` to include the new Phase A datasets.
- Added/finished schema helper APIs:
  - `dataset_columns`
  - `dataset_dtypes`
  - `validate_columns`
  - `validate_dtypes`
  - `order_columns`
  - `coerce_frame`
- Added typed result objects for future pipeline return values:
  - `ResultStats`
  - `PipelineResult`
  - `SnapshotResult`
  - `ModelValidationBundleResult`
  - `ResearchBundleResult`
  - `BackfillResult`
- Added model-validation manifest required-field validation.
- Added guardrails against obvious secret-looking manifest keys.
- Replaced the placeholder pseudo-implementation in `pipeline.py` with a clean Phase A1 boundary docstring.
- Added Phase A storage partition ordering for silver/gold artifacts.
- Added default overwrite protection to frame and manifest writes.
- Added schema, storage, and contract/storage integration tests.

## Test plan
- [ ] `ruff check .`
- [ ] `black --check .`
- [ ] `mypy`
- [ ] `pytest -q tests`
- [ ] notebooks: `pytest -q demos --nbmake` (if applicable)

## Docs
- [ ] README / docs updated (if needed)

## Notes / risks
Reviewers should pay attention to the exact Phase A field names and dtypes, especially:
- nullable pandas dtypes such as `Float64` and `Int64`
- UTC timestamp handling versus date-like expiry fields
- whether `model_validation_bundle` should remain manifest-only with empty tabular columns
- whether `dividend_yield_source` should replace or coexist with the older `dividend_source` naming
- whether the manifest validation belongs in `schemas.py`, `storage.py`, or a separate contract module long term

This PR intentionally does not implement providers, network calls, fixture loading, normalization logic, quote cleaning, Heston conversion, or CLI orchestration.